### PR TITLE
NormData Refactor

### DIFF
--- a/src/dotnet/design/Mil/Navy/Nrl/Norm/NormData.puml
+++ b/src/dotnet/design/Mil/Navy/Nrl/Norm/NormData.puml
@@ -1,7 +1,7 @@
 @startuml
 class NormData {
     ~ NormData(handle:long)
-    + byte[] Data <<get>>   
+    + byte[] GetData()
 }
 NormObject <|-- NormData
 @enduml

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
@@ -18,10 +18,7 @@ namespace Mil.Navy.Nrl.Norm
             var dataPointer = NormDataAccessData(_handle);
             var length = NormObjectGetSize(_handle);
             var data = new byte[length];
-            for (var i = 0; i < length; i++)
-            {
-                data[i] = Marshal.ReadByte(dataPointer, i);
-            }
+            Marshal.Copy(dataPointer, data, 0, length);
             return data;
         }
 

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
@@ -3,7 +3,7 @@
 namespace Mil.Navy.Nrl.Norm
 {
     /// <summary>
-    /// A transport object of type NORM_OBJECT_FILE.
+    /// A transport object of type NORM_OBJECT_DATA.
     /// </summary>
     /// <remarks>
     /// The data storage area for the specified transport object.

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormData.cs
@@ -11,21 +11,18 @@ namespace Mil.Navy.Nrl.Norm
     public class NormData : NormObject
     {
         /// <summary>
-        /// The data storage area associated with a transport object of type NORM_OBJECT_DATA.
+        /// Get the data storage area associated with a transport object of type NORM_OBJECT_DATA.
         /// </summary>
-        public byte[] Data
+        public byte[] GetData()
         {
-            get
+            var dataPointer = NormDataAccessData(_handle);
+            var length = NormObjectGetSize(_handle);
+            var data = new byte[length];
+            for (var i = 0; i < length; i++)
             {
-                var dataPointer = NormDataAccessData(_handle);
-                var length = NormObjectGetSize(_handle);
-                var data = new byte[length];
-                for (var i = 0; i < length; i++)
-                {
-                    data[i] = Marshal.ReadByte(dataPointer, i);
-                }
-                return data;
+                data[i] = Marshal.ReadByte(dataPointer, i);
             }
+            return data;
         }
 
         /// <summary>

--- a/src/dotnet/tests/Mil.Navy.Nrl.Norm.IntegrationTests/NormSessionTests.cs
+++ b/src/dotnet/tests/Mil.Navy.Nrl.Norm.IntegrationTests/NormSessionTests.cs
@@ -412,7 +412,7 @@ namespace Mil.Navy.Nrl.Norm.IntegrationTests
                 var expectedEventTypes = new List<NormEventType> { NormEventType.NORM_TX_OBJECT_SENT, NormEventType.NORM_TX_QUEUE_EMPTY };
                 var actualEventTypes = GetEvents().Select(e => e.Type).ToList();
                 Assert.Equal(expectedEventTypes, actualEventTypes);
-                var actualData = normData.Data;
+                var actualData = normData.GetData();
                 Assert.Equal(expectedData, actualData);
                 var actualContent = Encoding.ASCII.GetString(actualData);
                 Assert.Equal(expectedContent, actualContent);
@@ -466,7 +466,7 @@ namespace Mil.Navy.Nrl.Norm.IntegrationTests
                 var actualEvent = actualEvents.FirstOrDefault(e => e.Type == NormEventType.NORM_RX_OBJECT_COMPLETED);
                 var actualNormData = Assert.IsType<NormData>(actualEvent.Object);
                 
-                var actualData = actualNormData.Data;
+                var actualData = actualNormData.GetData();
                 Assert.Equal(expectedData, actualData);
                 var actualContent = Encoding.ASCII.GetString(actualData);
                 Assert.Equal(expectedContent, actualContent);

--- a/src/dotnet/tests/Mil.Navy.Nrl.Norm.IntegrationTests/NormSessionTests.cs
+++ b/src/dotnet/tests/Mil.Navy.Nrl.Norm.IntegrationTests/NormSessionTests.cs
@@ -93,7 +93,7 @@ namespace Mil.Navy.Nrl.Norm.IntegrationTests
             if (_isReceiverStarted && !_isReceiverStopped)
             {
                 _normSession.StopReceiver();
-                _isSenderStopped = true;
+                _isReceiverStopped = true;
             }
         }
 
@@ -464,7 +464,7 @@ namespace Mil.Navy.Nrl.Norm.IntegrationTests
                 Assert.Equivalent(expectedEventTypes, actualEventTypes);
 
                 var actualEvent = actualEvents.FirstOrDefault(e => e.Type == NormEventType.NORM_RX_OBJECT_COMPLETED);
-                var actualNormData = Assert.IsType<NormData>(actualEvent.Object);
+                var actualNormData = Assert.IsType<NormData>(actualEvent?.Object);
                 
                 var actualData = actualNormData.GetData();
                 Assert.Equal(expectedData, actualData);


### PR DESCRIPTION
Switched `NormData` `Data` property to a method and updated to use `Marshal.Copy`