### PR TITLE
NormDataEnqueue Refactor

### DIFF
--- a/src/dotnet/design/Mil/Navy/Nrl/Norm/NormApi.puml
+++ b/src/dotnet/design/Mil/Navy/Nrl/Norm/NormApi.puml
@@ -59,7 +59,8 @@ class NormApi
     + {static} NormSetGroupSize(sessionHandle:long, groupSize:long) : void 
     + {static} NormSetTxRobustFactor(sessionHandle:long, robustFactor:int) : void
     + {static} NormFileEnqueue(sessionHandle:long, fileName:string, infoPtr:string, infoLen:int): long 
-    + {static} NormDataEnqueue(sessionHandle:long, dataPtr:byte[], dataLen:int, infoPtr:byte[], infoLen:int) : long 
+    + {static} NormDataEnqueue(sessionHandle:long, dataPtr:nint, dataLen:int, infoPtr:nint, infoLen:int) : long 
+    + {static} NormDataEnqueue(sessionHandle:long, data:byte[], dataLen:int, info:byte[], infoLen:int) : long 
     + {static} NormRequeueObject(sessionHandle:long, objectHandle:long) : bool
     + {static} NormStreamOpen(sessionHandle:long, bufferSize:long, infoPtr:string, infoLen:int) : long 
     + {static} NormStreamClose(streamHandle:long, graceful:bool) : void 

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
@@ -542,7 +542,45 @@ namespace Mil.Navy.Nrl.Norm
         /// NORM_INFO content is left to the application's discretion</param>
         /// <returns>A NormObjectHandle is returned which the application may use in other NORM API calls as needed.</returns>
         [DllImport(NORM_LIBRARY)]
-        public static extern long NormDataEnqueue(long sessionHandle, byte[] dataPtr, int dataLen, byte[]? infoPtr, int infoLen);
+        public static extern long NormDataEnqueue(long sessionHandle, nint dataPtr, int dataLen, nint infoPtr, int infoLen);
+
+        /// <summary>
+        /// This function enqueues a segment of application memory space for transmission within the specified NORM sessionHandle.
+        /// </summary>
+        /// <param name="sessionHandle">Used to identify application in the NormSession.</param>
+        /// <param name="data">The data parameter must be a managed buffer to be transmitted.</param>
+        /// <param name="dataLen">The dataLen parameter indicates the quantity of data to transmit.</param>
+        /// <param name="info">The optional info and infoLen parameters 
+        /// are used to associate NORM_INFO content with the sent transport object. The maximum allowed infoLen
+        /// corresponds to the segmentSize used in the prior call to NormStartSender(). The use and interpretation of the
+        /// NORM_INFO content is left to the application's discretion.</param>
+        /// <param name="infoLen">The optional info and infoLen parameters 
+        /// are used to associate NORM_INFO content with the sent transport object. The maximum allowed infoLen
+        /// corresponds to the segmentSize used in the prior call to NormStartSender(). The use and interpretation of the
+        /// NORM_INFO content is left to the application's discretion</param>
+        /// <returns>A NormObjectHandle is returned which the application may use in other NORM API calls as needed.</returns>
+        public static long NormDataEnqueue(long sessionHandle, byte[] data, int dataLen, byte[]? info, int infoLen)
+        {
+            long objectHandle;
+            var dataPtr = Marshal.AllocHGlobal(dataLen);
+            var infoPtr = Marshal.AllocHGlobal(infoLen);
+
+            try
+            {
+                Marshal.Copy(data, 0, dataPtr, dataLen);
+                if (info != null)
+                {
+                    Marshal.Copy(info, 0, infoPtr, infoLen);
+                }
+                objectHandle = NormDataEnqueue(sessionHandle, dataPtr, dataLen, infoPtr, infoLen);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(dataPtr);
+                Marshal.FreeHGlobal(infoPtr);
+            }
+            return objectHandle;
+        }
 
         /// <summary>
         /// This function allows the application to resend (or reset transmission of) a NORM_OBJECT_FILE or NORM_OBJECT_DATA

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
@@ -542,7 +542,7 @@ namespace Mil.Navy.Nrl.Norm
         /// NORM_INFO content is left to the application's discretion</param>
         /// <returns>A NormObjectHandle is returned which the application may use in other NORM API calls as needed.</returns>
         [DllImport(NORM_LIBRARY)]
-        public static extern long NormDataEnqueue(long sessionHandle, nint dataPtr, int dataLen, byte[]? info, int infoLen);
+        public static extern long NormDataEnqueue(long sessionHandle, nint dataPtr, int dataLen, nint infoPtr, int infoLen);
 
         /// <summary>
         /// This function enqueues a segment of application memory space for transmission within the specified NORM sessionHandle.
@@ -563,15 +563,18 @@ namespace Mil.Navy.Nrl.Norm
         {
             long objectHandle;
             var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            var infoHandle = GCHandle.Alloc(info, GCHandleType.Pinned);
             
             try
             {
                 var dataPtr = dataHandle.AddrOfPinnedObject();
-                objectHandle = NormDataEnqueue(sessionHandle, dataPtr, dataLen, info, infoLen);
+                var infoPtr = infoHandle.AddrOfPinnedObject();
+                objectHandle = NormDataEnqueue(sessionHandle, dataPtr, dataLen, infoPtr, infoLen);
             }
             finally
             {
                 dataHandle.Free();
+                infoHandle.Free();
             }
             return objectHandle;
         }

--- a/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
+++ b/src/dotnet/src/Mil.Navy.Nrl.Norm/NormApi.cs
@@ -542,7 +542,7 @@ namespace Mil.Navy.Nrl.Norm
         /// NORM_INFO content is left to the application's discretion</param>
         /// <returns>A NormObjectHandle is returned which the application may use in other NORM API calls as needed.</returns>
         [DllImport(NORM_LIBRARY)]
-        public static extern long NormDataEnqueue(long sessionHandle, nint dataPtr, int dataLen, nint infoPtr, int infoLen);
+        public static extern long NormDataEnqueue(long sessionHandle, nint dataPtr, int dataLen, byte[]? info, int infoLen);
 
         /// <summary>
         /// This function enqueues a segment of application memory space for transmission within the specified NORM sessionHandle.
@@ -562,22 +562,16 @@ namespace Mil.Navy.Nrl.Norm
         public static long NormDataEnqueue(long sessionHandle, byte[] data, int dataLen, byte[]? info, int infoLen)
         {
             long objectHandle;
-            var dataPtr = Marshal.AllocHGlobal(dataLen);
-            var infoPtr = Marshal.AllocHGlobal(infoLen);
-
+            var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            
             try
             {
-                Marshal.Copy(data, 0, dataPtr, dataLen);
-                if (info != null)
-                {
-                    Marshal.Copy(info, 0, infoPtr, infoLen);
-                }
-                objectHandle = NormDataEnqueue(sessionHandle, dataPtr, dataLen, infoPtr, infoLen);
+                var dataPtr = dataHandle.AddrOfPinnedObject();
+                objectHandle = NormDataEnqueue(sessionHandle, dataPtr, dataLen, info, infoLen);
             }
             finally
             {
-                Marshal.FreeHGlobal(dataPtr);
-                Marshal.FreeHGlobal(infoPtr);
+                dataHandle.Free();
             }
             return objectHandle;
         }


### PR DESCRIPTION
Updated the `NormDataEnqueue` `extern` method to use `IntPtr` and added a wrapper method that takes the managed buffer and handles the pinning/unpinning.